### PR TITLE
Handle missing IP/gateway when interface has no address

### DIFF
--- a/tools/setip.sh
+++ b/tools/setip.sh
@@ -237,12 +237,14 @@ parse_params() {
 
 get_current_prefix() {
   local iface="$1"
-  ip -o -f inet addr show "$iface" | awk 'NR==1 {split($4,a,"/"); print a[2]}'
+  # 当网卡当前没有 IPv4 地址时，ip 命令会返回非 0，避免 set -e 提前退出
+  (ip -o -f inet addr show "$iface" 2>/dev/null || true) | awk 'NR==1 {split($4,a,"/"); print a[2]}'
 }
 
 get_current_gateway() {
   local iface="$1"
-  ip route show default dev "$iface" | awk 'NR==1{print $3}'
+  # 没有默认路由时 ip route 也可能返回非 0，同样兜底避免脚本中断
+  (ip route show default dev "$iface" 2>/dev/null || true) | awk 'NR==1{print $3}'
 }
 
 get_current_dns() {


### PR DESCRIPTION
## Summary
- prevent setip from aborting when the selected interface currently lacks an IPv4 address
- allow default gateway lookup to fail without terminating the script under set -e

## Testing
- bash -n tools/setip.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943c85d29c48331b94a1fafa708bd10)